### PR TITLE
fix error introduced in 51a1f9c to allow main in events_cmax.py to run

### DIFF
--- a/utils/event_utils.py
+++ b/utils/event_utils.py
@@ -271,7 +271,7 @@ def events_to_zhu_timestamp_image(xn, yn, ts, pn,
     """
     Legacy, use events_to_timestamp_image instead
     """
-    events_to_timestamp_image(xn, yn, ts, pn, device=device, sensor_size=sensor_size,
+    return events_to_timestamp_image(xn, yn, ts, pn, device=device, sensor_size=sensor_size,
             clip_out_of_range=clip_out_of_range, interpolation=interpolation)
 
 def events_to_image_torch(xs, ys, ps,

--- a/utils/objectives.py
+++ b/utils/objectives.py
@@ -384,7 +384,7 @@ class zhu_timestamp_objective(objective_function):
             xs, ys, jx, jy = warpfunc.warp(xs, ys, ts, ps, ts[-1], params, compute_grad=False)
             mask = events_bounds_mask(xs, ys, 0, img_size[1], 0, img_size[0])
             xs, ys, ts, ps = xs*mask, ys*mask, ts*mask, ps*mask
-            posimg, negimg = events_to_zhu_timestamp_image(xs, ys, ts, ps, compute_gradient=False, showimg=showimg)
+            posimg, negimg = events_to_zhu_timestamp_image(xs, ys, ts, ps)
         blur_sigma=self.default_blur if blur_sigma is None else blur_sigma
         if blur_sigma > 0:
             posimg = gaussian_filter(posimg, blur_sigma)


### PR DESCRIPTION
Cool repo and fine work in your papers in general. Found an error while evaluating your code, the main in events_cmax.py doesn't run due to an error introduced during a refactor in 51a1f9c. This seems to be an appropriate fix but let me know if there is something I missed.

Hope this is helpful.